### PR TITLE
feat(cli): add configuration inspection command

### DIFF
--- a/config/example.toml
+++ b/config/example.toml
@@ -1,4 +1,6 @@
 # Minimal runtime configuration for papersys
+# Validate with: uv run --no-progress python -m papersys.cli config check --format text
+# Inspect schema: uv run --no-progress python -m papersys.cli config explain
 
 # Legacy/general settings
 data_root = "./data"

--- a/devdoc/architecture.md
+++ b/devdoc/architecture.md
@@ -118,6 +118,14 @@
 
 示例配置 `config/example.toml` 包含完整字段，单元测试 `tests/config/test_*.py` 覆盖各层级读取与严格性校验，CLI `status --dry-run` 输出详细状态。
 
+### 配置可观测性工具
+
+- 新增 `config` CLI 子命令：
+  - `uv run --no-progress python -m papersys.cli config check` 会读取指定 `--config` 文件并输出校验结果，支持 `--format text|json`，CI 可解析 JSON 检查 `status/warnings`。
+  - `uv run --no-progress python -m papersys.cli config explain` 生成字段说明，文本模式通过日志打印层级结构，JSON 模式返回机器可读的字段数组。
+- 检查流程会提示弃用字段（如 `data_root`/`embedding_models`）与缺失的关键模块配置，帮助上线前发现问题。
+- `config/example.toml` 在文件头追加了命令提示，便于新用户快速完成自检。
+
 ### 运行编排与调度
 
 - **核心调度器**：使用 `APScheduler` 或 `Prefect` 在本地长驻进程中管理每日任务（爬虫→嵌入→推荐→摘要→发布）。

--- a/devlog/2025-10-config-observability-cli.md
+++ b/devlog/2025-10-config-observability-cli.md
@@ -1,0 +1,59 @@
+# 配置可观测性工具开发日志（2025-10-04）
+
+## 1. 背景与目标
+- 需求来源：`devdoc/todo/TODO-config-observability.md` 提出的 CLI 配置检查工具。
+- 现状痛点：当前 `papersys.cli` 仅支持 `status/summarize/serve`，无法在部署前快速验证 `config.toml`。
+- 目标：新增 `config` 子命令，提供机器可读输出与字段说明，配套测试与文档更新，降低配置出错成本。
+
+## 2. 相关文件与模块
+- `papersys/cli.py`：CLI 入口，需要扩展解析与命令执行逻辑。
+- `papersys/config/*`：Pydantic 模型，需提取字段描述、检测弃用字段。
+- `tests/cli/`：补充 pytest 覆盖典型错误场景。
+- `config/example.toml`：示例配置需同步新增提示或字段。
+- `devdoc/architecture.md`：文档同步新增 CLI 能力。
+
+## 3. 风险分析
+| 风险 | 描述 | 应对策略 |
+| ---- | ---- | ---- |
+| JSON 输出被日志污染 | Loguru 默认输出到 stderr，若误写入 stdout 会破坏机器可读性 | 严格区分 stdout/stderr，JSON 仅使用 `print()` 输出 |
+| Pydantic 类型字符串化复杂 | 嵌套 Optional/List 等类型难以转换 | 编写独立的类型格式化工具，fallback 到 `repr`，并在测试中覆盖 |
+| 校验失败信息晦涩 | 直接抛出 ValidationError 难排查 | 捕获异常并整理为统一错误结构，文本模式提供重点提示 |
+| CLI 参数解析混乱 | 嵌套子命令易遗漏必选参数 | 使用 `set_defaults`/`required=True` 确保 `config` 子命令必须指定动作 |
+
+## 4. 开发方案
+1. **结构化校验工具**：在 `papersys/config/inspector.py` 新增 `check_config()`、`explain_config()` 函数，封装加载、错误整理、字段文档生成。
+2. **CLI 集成**：`papersys/cli.py` 新增 `config` 子命令，支持 `check` 与 `explain`，提供 `--format`（`text`/`json`），`--explain` 由子命令区分。
+3. **输出策略**：
+   - `text`：使用 `logger` 输出摘要、警告与错误。
+   - `json`：返回结构化字典（status, warnings, errors, fields）。
+4. **测试覆盖**：
+   - 成功校验 + JSON 输出。
+   - 缺失文件。
+   - 校验失败（非法字段）。
+   - `explain` 命令输出包含嵌套字段。
+5. **文档与示例**：
+   - 在 `config/example.toml` 顶部增加调用提示。
+   - `devdoc/architecture.md` 增补“配置可观测性”段落说明。
+
+## 5. 预期效果
+- CLI 能快速校验配置并提示弃用字段，JSON 输出可用于 CI。
+- 文档指导用户使用新命令，示例配置提示自检方式。
+
+## 6. 潜在问题与补救
+- 若字段说明递归时遇到循环引用，使用集合记录已访问模型以避免无限递归。
+- 若未来新增字段缺少描述，`explain` 输出会空描述，需在评审时提醒补充。
+
+## 7. 测试计划
+- `uv run --no-progress pytest tests/cli/test_cli_config.py -v`
+- `uv run --no-progress pytest tests/cli -v`
+- 按需回归 `uv run --no-progress pytest tests/config -v` 以确保无回归。
+
+## 8. 实施结果（2025-10-04）
+- 完成 `papersys/config/inspector.py` 新增校验与说明逻辑，支持递归输出嵌套字段，并对 `UnionType` 做了兼容处理。
+- `papersys/cli.py` 引入 `config` 子命令及 `--format` 切换，文本模式通过 Loguru 输出可读信息，JSON 模式适用于 CI。
+- 新增 `tests/cli/test_cli_config.py` 覆盖成功校验、缺失文件、校验失败与解释输出等核心场景。
+- `config/example.toml` 与 `devdoc/architecture.md` 补充了使用指引，确保文档同步。
+- 测试执行：
+  - `uv run --no-progress pytest tests/cli/test_cli_config.py -v`
+  - `uv run --no-progress pytest tests/cli -v`
+

--- a/papersys/cli.py
+++ b/papersys/cli.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 
 import uvicorn
 from loguru import logger
 
 from .config import AppConfig, load_config
+from .config.inspector import check_config, explain_config
 from .recommend import RecommendationDataLoader
 from .scheduler import SchedulerService
 from .summary import SummaryPipeline
@@ -58,6 +60,27 @@ def build_parser() -> argparse.ArgumentParser:
         help="Set up the scheduler and report status without running the server",
     )
 
+    config_parser = subparsers.add_parser("config", help="Validate and document configuration files")
+    config_subparsers = config_parser.add_subparsers(dest="config_command")
+    if hasattr(config_subparsers, "required"):
+        config_subparsers.required = True  # type: ignore[attr-defined]
+
+    check_parser = config_subparsers.add_parser("check", help="Validate the configuration file")
+    check_parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format for validation results",
+    )
+
+    explain_parser = config_subparsers.add_parser("explain", help="Describe available configuration fields")
+    explain_parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format for configuration schema",
+    )
+
     return parser
 
 
@@ -66,10 +89,13 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     config_path = args.config.resolve()
+    command = args.command
+    if command == "config":
+        return _handle_config_command(args, config_path)
+
     logger.info("Loading configuration from {}", config_path)
     config = load_config(AppConfig, config_path)
 
-    command = args.command
     if command is None:
         if args.dry_run:
             _report_system_status(config)
@@ -124,6 +150,63 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     logger.warning("Unknown command: {}", command)
+    return 1
+
+
+def _handle_config_command(args: argparse.Namespace, config_path: Path) -> int:
+    config_command = getattr(args, "config_command", None)
+    output_format = getattr(args, "format", "text")
+
+    if config_command == "check":
+        result, exit_code, _ = check_config(config_path)
+        if output_format == "json":
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+            return exit_code
+
+        if result["status"] == "ok":
+            logger.info("Configuration OK: {}", result["config_path"])
+            for warning in result["warnings"]:
+                logger.warning(warning)
+        else:
+            error = result["error"]
+            logger.error(
+                "Configuration error ({}) for {}: {}",
+                error["type"],
+                result["config_path"],
+                error["message"],
+            )
+            for detail in error.get("details", []):
+                location = detail["loc"] or "<root>"
+                logger.error("  - {}: {} ({})", location, detail["message"], detail["type"])
+        return exit_code
+
+    if config_command == "explain":
+        fields = explain_config()
+        if output_format == "json":
+            print(json.dumps({"fields": fields}, indent=2, ensure_ascii=False))
+            return 0
+
+        logger.info("Configuration schema ({} fields):", len(fields))
+        for field in fields:
+            default_value = field["default"]
+            if isinstance(default_value, (dict, list)):
+                default_repr = json.dumps(default_value, ensure_ascii=False)
+            elif default_value is None:
+                default_repr = "None"
+            else:
+                default_repr = str(default_value)
+            description = field["description"] or "(no description)"
+            logger.info(
+                "  - {name}: type={type}, required={required}, default={default}, description={description}",
+                name=field["name"],
+                type=field["type"],
+                required="yes" if field["required"] else "no",
+                default=default_repr,
+                description=description,
+            )
+        return 0
+
+    logger.warning("Unknown config subcommand: {}", config_command)
     return 1
 
 

--- a/papersys/config/inspector.py
+++ b/papersys/config/inspector.py
@@ -1,0 +1,225 @@
+"""Utilities for inspecting and validating configuration files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import UnionType
+from typing import Any, Iterable, Union, get_args, get_origin
+
+from pydantic import BaseModel, ValidationError
+from pydantic.fields import FieldInfo
+
+from .app import AppConfig
+from .base import load_config
+
+
+ConfigModel = AppConfig
+
+
+class ConfigInspectionError(RuntimeError):
+    """Raised when configuration inspection fails unexpectedly."""
+
+
+def check_config(path: Path, *, config_cls: type[ConfigModel] = ConfigModel) -> tuple[dict[str, Any], int, ConfigModel | None]:
+    """Validate the configuration file and collect warnings.
+
+    Returns a tuple of ``(result_dict, exit_code, config_instance_or_None)``.
+    """
+
+    try:
+        config = load_config(config_cls, path)
+    except FileNotFoundError as exc:
+        return (
+            {
+                "status": "error",
+                "config_path": str(path),
+                "error": {
+                    "type": "missing_file",
+                    "message": str(exc),
+                },
+            },
+            2,
+            None,
+        )
+    except ValidationError as exc:
+        return (
+            {
+                "status": "error",
+                "config_path": str(path),
+                "error": {
+                    "type": "validation_error",
+                    "message": "Configuration validation failed",
+                    "details": [
+                        {
+                            "loc": _format_error_location(err["loc"]),
+                            "message": err["msg"],
+                            "type": err["type"],
+                        }
+                        for err in exc.errors()
+                    ],
+                },
+            },
+            3,
+            None,
+        )
+    except PermissionError as exc:
+        return (
+            {
+                "status": "error",
+                "config_path": str(path),
+                "error": {
+                    "type": "permission_error",
+                    "message": str(exc),
+                },
+            },
+            2,
+            None,
+        )
+    except ValueError as exc:
+        return (
+            {
+                "status": "error",
+                "config_path": str(path),
+                "error": {
+                    "type": "invalid_format",
+                    "message": str(exc),
+                },
+            },
+            1,
+            None,
+        )
+    except Exception as exc:  # pragma: no cover - unexpected failures
+        raise ConfigInspectionError("Unexpected configuration inspection error") from exc
+
+    warnings = _collect_warnings(config)
+    result = {
+        "status": "ok",
+        "config_path": str(path),
+        "warnings": warnings,
+    }
+    return result, 0, config
+
+
+def explain_config(*, config_cls: type[ConfigModel] = ConfigModel) -> list[dict[str, Any]]:
+    """Describe configuration fields for documentation purposes."""
+
+    documentation: list[dict[str, Any]] = []
+    visited: set[type[BaseModel]] = set()
+
+    def _walk(model_cls: type[BaseModel], prefix: str = "") -> None:
+        if model_cls in visited:
+            return
+        visited.add(model_cls)
+
+        for field_name, field in model_cls.model_fields.items():
+            entry = {
+                "name": f"{prefix}{field_name}",
+                "type": _format_annotation(field.annotation),
+                "required": field.is_required(),
+                "default": _format_default(field),
+                "description": field.description or "",
+            }
+            documentation.append(entry)
+
+            for nested_cls, nested_prefix in _iter_nested_models(field, base_prefix=f"{prefix}{field_name}"):
+                _walk(nested_cls, nested_prefix)
+
+    _walk(config_cls)
+    return documentation
+
+
+def _format_error_location(location: Iterable[Union[int, str]]) -> str:
+    return ".".join(str(part) for part in location)
+
+
+def _collect_warnings(config: ConfigModel) -> list[str]:
+    warnings: list[str] = []
+
+    if config.data_root is not None:
+        warnings.append("'data_root' is deprecated; prefer module-specific base paths")
+    if config.embedding_models:
+        warnings.append("'embedding_models' is legacy and will be removed in future versions")
+    if config.scheduler_enabled and config.scheduler is None:
+        warnings.append("'scheduler_enabled' is true but no scheduler block is configured")
+    if not config.llms:
+        warnings.append("No LLM configurations defined; summary pipeline may not function")
+
+    return warnings
+
+
+def _format_annotation(annotation: Any) -> str:
+    origin = get_origin(annotation)
+    if origin is None:
+        if isinstance(annotation, type):
+            return annotation.__name__
+        return repr(annotation).replace("typing.", "")
+
+    args = get_args(annotation)
+    if origin in {Union, UnionType}:
+        non_none = [arg for arg in args if arg is not type(None)]  # noqa: E721
+        if len(non_none) == 1 and len(args) == 2:
+            return f"Optional[{_format_annotation(non_none[0])}]"
+        joined = ", ".join(_format_annotation(arg) for arg in args)
+        return f"Union[{joined}]"
+
+    origin_name = getattr(origin, "__name__", repr(origin).replace("typing.", ""))
+    if args:
+        joined_args = ", ".join(_format_annotation(arg) for arg in args)
+        return f"{origin_name}[{joined_args}]"
+    return origin_name
+
+
+def _format_default(field: FieldInfo) -> Any:
+    if field.default_factory is not None:
+        try:
+            value = field.default_factory()
+        except Exception:  # pragma: no cover - factory failure is unexpected
+            return "<factory>"
+        return _stringify_default(value)
+    if field.is_required():
+        return None
+    return _stringify_default(field.default)
+
+
+def _stringify_default(value: Any) -> Any:
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, BaseModel):
+        return value.model_dump()
+    if isinstance(value, (list, tuple)):
+        return [_stringify_default(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _stringify_default(val) for key, val in value.items()}
+    return value
+
+
+def _iter_nested_models(field: FieldInfo, *, base_prefix: str) -> list[tuple[type[BaseModel], str]]:
+    nested: list[tuple[type[BaseModel], str]] = []
+    annotation = field.annotation
+    origin = get_origin(annotation)
+    if origin is None:
+        if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+            nested.append((annotation, f"{base_prefix}."))
+        return nested
+
+    args = get_args(annotation)
+    if origin in {Union, UnionType}:
+        for arg in args:
+            if isinstance(arg, type) and issubclass(arg, BaseModel):
+                nested.append((arg, f"{base_prefix}."))
+        return nested
+
+    if origin in {list, tuple, set}:  # handle homogeneous collections
+        if args and isinstance(args[0], type) and issubclass(args[0], BaseModel):
+            nested.append((args[0], f"{base_prefix}[]."))
+        return nested
+
+    if origin is dict:
+        if len(args) == 2 and isinstance(args[1], type) and issubclass(args[1], BaseModel):
+            nested.append((args[1], f"{base_prefix}{{}}."))
+        return nested
+
+    return nested
+
+
+__all__ = ["check_config", "explain_config", "ConfigInspectionError"]

--- a/tests/cli/test_cli_config.py
+++ b/tests/cli/test_cli_config.py
@@ -1,0 +1,93 @@
+import json
+import sys
+from contextlib import contextmanager
+
+from loguru import logger
+
+from papersys.cli import main
+
+
+@contextmanager
+def _logger_to_stderr():
+    logger_id = logger.add(sys.stderr, level="INFO")
+    try:
+        yield
+    finally:
+        logger.remove(logger_id)
+
+
+def test_config_check_json_success(capsys, tmp_path):
+    config_text = """
+[scheduler]
+enabled = true
+timezone = "UTC"
+
+[summary_pipeline.pdf]
+output_dir = "./pdfs"
+model = "deepseek-r1"
+language = "en"
+
+enable_latex = false
+
+[[llms]]
+alias = "deepseek-r1"
+name = "deepseek"
+base_url = "https://example.com"
+api_key = "env:DEEPSEEK_API_KEY"
+temperature = 0.1
+top_p = 0.9
+num_workers = 1
+native_json_schema = false
+"""
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(config_text)
+
+    with _logger_to_stderr():
+        exit_code = main(["--config", str(config_file), "config", "check", "--format", "json"])
+
+    assert exit_code == 0
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["status"] == "ok"
+    assert payload["warnings"] == []
+    assert payload["config_path"].endswith("config.toml")
+
+
+def test_config_check_missing_file(capsys, tmp_path):
+    missing_path = tmp_path / "absent.toml"
+
+    with _logger_to_stderr():
+        exit_code = main(["--config", str(missing_path), "config", "check"])
+
+    assert exit_code == 2
+
+    captured = capsys.readouterr()
+    assert "Configuration error (missing_file" in captured.err
+    assert str(missing_path) in captured.err
+
+
+def test_config_check_validation_error(capsys, tmp_path):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text("unknown_field = 42\n")
+
+    with _logger_to_stderr():
+        exit_code = main(["--config", str(config_file), "config", "check"])
+
+    assert exit_code == 3
+
+    captured = capsys.readouterr()
+    assert "validation_error" in captured.err
+    assert "Extra inputs are not permitted" in captured.err
+
+
+def test_config_explain_text_output(capsys):
+    with _logger_to_stderr():
+        exit_code = main(["config", "explain"])
+
+    assert exit_code == 0
+
+    captured = capsys.readouterr()
+    assert "Configuration schema" in captured.err
+    assert "summary_pipeline.pdf.model" in captured.err
+    assert "llms[].alias" in captured.err


### PR DESCRIPTION
## Summary
- add a configuration inspector module and integrate a `config` CLI subcommand that supports `check` and `explain` with text/JSON outputs
- document the new workflow in the architecture notes and annotate the sample config with validation helpers
- record the development plan/execution log for the configuration observability tooling

## Testing
- uv run --no-progress pytest tests/cli/test_cli_config.py -v
- uv run --no-progress pytest tests/cli -v


------
https://chatgpt.com/codex/tasks/task_e_68de0d1c57a48333aa33b12a17e96150