### PR TITLE
feat: add web console ui and auth guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# PaperDigestMono
+
+## Web 控制台快速上手
+
+仓库内置的 FastAPI 应用现在包含一个轻量级的 Web 控制台，可查看 APScheduler 中注册的任务并手动触发。以下步骤可帮助你快速启用：
+
+### 1. 配置访问令牌（可选但推荐）
+
+在运行服务前，编辑你的配置文件（示例见 `config/example.toml`），新增或修改以下段落：
+
+```toml
+[web]
+enabled = true
+title = "PaperDigest Scheduler Console"
+
+[web.auth]
+enabled = true
+header_name = "X-Console-Token"
+token = "your-secret-token"
+```
+
+- 将 `token` 替换为你的共享密钥；若留空且 `enabled = true`，启动时会报错。
+- 如需开放访问，可把 `[web.auth]` 删除或设置 `enabled = false`。
+
+### 2. 启动 FastAPI 应用
+
+```bash
+uv run uvicorn papersys.web.app:create_app --factory --host 0.0.0.0 --port 8000
+```
+
+应用会加载 `config` 中的调度配置，控制台访问路径为 `http://localhost:8000/console`。根路径会自动重定向到控制台；未启用 UI 时将返回提示信息。
+
+### 3. 使用 Web 控制台
+
+- 页面会实时拉取 `/jobs` 接口返回的任务列表，并显示名称与 cron 表达式。
+- 点击任意任务后的 “Run” 按钮即可调用 `/scheduler/run/{job_id}` 手动触发。
+- 当启用了鉴权时，页面顶部会出现 Token 输入框。令牌仅保存在当前浏览器的 LocalStorage，不会上传服务器。
+- API 直接访问同样需要在请求头中携带 `header_name` 对应的 Token 值，否则返回 401。
+
+### 4. 健康检查与自动化
+
+- `/health`：简单的存活探针，无需 Token。
+- `/jobs`、`/scheduler/run/{job_id}`：在启用 Token 后将严格校验。
+- 可在 CI 或脚本中通过 `X-Console-Token` 请求头调用接口，实现自动化触发。
+
+如需更多配置字段或模块说明，请参阅 `devdoc/` 目录下的文档。

--- a/config/example.toml
+++ b/config/example.toml
@@ -6,6 +6,16 @@ scheduler_enabled = true
 embedding_models = ["jasper_v1"]
 logging_level = "INFO"
 
+# Web console configuration
+[web]
+enabled = true
+title = "PaperDigest Scheduler Console"
+
+[web.auth]
+enabled = true
+header_name = "X-Console-Token"
+token = "change-me"
+
 # Scheduler configuration
 [scheduler]
 enabled = true

--- a/devlog/2025-10-web-console-ui.md
+++ b/devlog/2025-10-web-console-ui.md
@@ -1,0 +1,74 @@
+# Web 控制台与鉴权改造计划（2025-10-03）
+
+## 一、背景与目标
+
+当前 FastAPI 服务仅提供 JSON API（`/health`、`/jobs`、`/scheduler/run/{job_id}`），缺少人性化的界面来查看任务状态与手动触发。同时，接口没有任何访问控制，生产部署时存在被误触发或恶意触发的风险。本次需求旨在：
+
+1. 追加一个轻量级 Web 控制台，复用现有 API 展示任务列表并提供手动触发入口；
+2. 引入配置化的请求头 Token 鉴权，保护关键接口；
+3. 补充端到端/HTTP 层测试，确保受保护的触发流程仍可用；
+4. 更新文档说明启用方式与 UI 功能，降低运维接入成本。
+
+## 二、现状分析
+
+- **后端结构**：`papersys/web/app.py` 当前只注册 JSON 路由，未包含模板或静态资源支持。`create_app()` 仅依赖 `SchedulerService`，与配置体系 (`papersys/config/app.py`) 没有直接联动。
+- **调度服务**：`papersys/scheduler/service.py` 提供 `list_jobs()` 与 `trigger_job()`，能满足前端展示/手动触发的业务需求。
+- **配置体系**：`config/example.toml` 已通过 `AppConfig` 管理，但无 Web/UI 或鉴权相关字段。
+- **测试现状**：`tests/web/test_app.py` 覆盖现有 API，但未涉及鉴权或 UI。无端到端交互测试。
+
+## 三、涉及模块与潜在影响
+
+| 模块 | 文件 | 变更点 | 影响评估 |
+| ---- | ---- | ------ | -------- |
+| Web 应用 | `papersys/web/app.py` | 引入模板渲染、静态响应、请求头鉴权依赖 | 需确保现有 JSON API 向后兼容；`create_app` 签名调整后要同步更新调用处与测试 |
+| 配置 | `papersys/config/app.py`、`papersys/config/__init__.py` | 新增 Web/Auth 配置模型 | TOML 结构变化需更新示例配置与潜在加载逻辑 |
+| 配置样例 | `config/example.toml` | 添加 Web 控制台与鉴权字段 | 需要说明默认关闭或默认 Token 行为 |
+| 前端资源 | `papersys/web/templates/*`, `papersys/web/static/*` | 新增模板与样式脚本 | 确保 FastAPI 可正确加载；注意包内资源路径 |
+| 测试 | `tests/web/test_app.py` 或新增文件 | 扩展用例覆盖鉴权与 UI 基本加载 | 运行 `pytest` 保证通过 |
+| 文档 | `README.md` 或 `devdoc/env.md` | 说明开启控制台与配置方法 | 便于部署者启用 |
+
+## 四、风险分析与应对
+
+1. **鉴权误伤合法请求**：若默认强制 Token，可能导致本地调试失败。→ 计划将 Token 配置设为可选，未配置时放行；配置后统一校验。
+2. **模板加载失败**：打包路径错误或未在 FastAPI 中正确挂载可能导致 500。→ 使用 `pathlib` 获取 `templates` 目录，通过 `Jinja2Templates` 注册；配合测试验证 `/console` 正常响应。
+3. **接口兼容性问题**：`create_app` 签名变动可能影响其他导入方。→ 提供默认参数（如 `auth_config=None`），并在测试中覆盖旧行为。
+4. **前端交互不可用**：手动触发按钮调用失败或缺乏 Token 时无法工作。→ 设计前端逻辑：在页面中允许输入 Token 后再触发；编写 HTTP 层测试模拟有 Token 的请求。
+5. **测试覆盖不足**：端到端交互需验证 401/200 场景。→ 新增 pytest 用例覆盖缺失 Token、Token 正确、错误 Token 三种情况，并确保 `/console` 返回 HTML。
+
+## 五、开发方案
+
+1. **配置扩展**：
+   - 新增 `WebAuthConfig`（字段：`enabled`、`header_name`、`token`）与 `WebUIConfig`（字段：`enabled`、`title` 等）模型，挂载到 `AppConfig`。
+   - 更新 `config/example.toml` 展示如何设置 Token（例如 `X-Console-Token`）。
+2. **后端改造**：
+   - 更新 `create_app`：接受 `AppConfig | None`，基于配置构建依赖。增加 `/console`（GET）渲染模板，静态加载简洁 CSS/JS。
+   - 实现统一依赖函数 `verify_token`，对 `/jobs` 和 `/scheduler/run/{job_id}` 设置 `Depends`。未配置 Token 时直接放行；启用后校验请求头。
+3. **前端实现**：
+   - 在 `templates/console.html` 中使用 `<template>` + `<script>` 生成表格。JavaScript 负责调用 `/jobs`、渲染列表，并在按钮点击时发送 `POST` 请求。若启用 Token，则从浏览器 `localStorage` 或用户输入框读取后附加到请求头。
+   - 简易样式保证响应式布局和可访问性（按钮具备 aria-label、键盘触发）。
+4. **测试编写**：
+   - 扩展 `tests/web/test_app.py`：覆盖 `/console` HTML 响应、鉴权缺失 401、错误 Token 401、正确 Token 200 + 触发成功。
+   - 保留现有断言，确保未开启 Token 时原逻辑仍生效。
+5. **文档更新**：
+   - 在 `README.md` 新增“Web 控制台”章节，说明启动 FastAPI、配置 Token、界面功能。
+
+## 六、风险规避与补救措施
+
+- 在实现前端之前先编写依赖和 API 层测试，确保后端鉴权逻辑稳定。
+- 如模板渲染出现路径问题，可通过 `TestClient` 的 `.get("/console")` 结果快速定位。
+- 若 UI JS 请求因 CORS/路径错误导致失败，可先在测试中对 `/jobs` 直接调用验证接口可用，再调试前端脚本。
+- 若最终 `pytest` 未通过，回滚到提交前状态，重新核对依赖注入逻辑。
+
+## 七、预期效果
+
+- Web 控制台可在桌面/移动端展示作业列表，并允许单击触发任务。
+- Token 鉴权默认关闭；启用后，未携带正确 Token 的请求将收到 401。
+- 新增测试覆盖关键流程，`uv run pytest` 全量通过。
+- README 文档明确说明部署者如何启用与使用控制台。
+
+## 八、测试计划
+
+- 开发完成后执行 `uv run pytest tests/web/test_app.py -v`，确保 Web 层测试通过。
+- 视情况补充运行 `uv run pytest` 全套，确认无回归。
+
+> 待用户确认后开始编码，若执行中发现遗漏，将在本日志追加“反思”段落并更新经验教训记录。

--- a/papersys/config/__init__.py
+++ b/papersys/config/__init__.py
@@ -14,6 +14,7 @@ from .recommend import (
 )
 from .scheduler import SchedulerConfig, SchedulerJobConfig
 from .summary import PdfConfig, SummaryPipelineConfig
+from .web import WebAuthConfig, WebUIConfig
 
 __all__ = [
     "BaseConfig",
@@ -29,4 +30,6 @@ __all__ = [
     "SchedulerJobConfig",
     "PdfConfig",
     "SummaryPipelineConfig",
+    "WebAuthConfig",
+    "WebUIConfig",
 ]

--- a/papersys/config/app.py
+++ b/papersys/config/app.py
@@ -11,6 +11,7 @@ from papersys.config.llm import LLMConfig
 from papersys.config.recommend import RecommendPipelineConfig
 from papersys.config.scheduler import SchedulerConfig
 from papersys.config.summary import SummaryPipelineConfig
+from papersys.config.web import WebUIConfig
 
 
 class AppConfig(BaseConfig):
@@ -27,6 +28,7 @@ class AppConfig(BaseConfig):
     summary_pipeline: SummaryPipelineConfig | None = None
     scheduler: SchedulerConfig | None = Field(None, description="Scheduler configuration")
     llms: list[LLMConfig] = Field(default_factory=list, description="Available LLM configurations")
+    web: WebUIConfig | None = Field(None, description="Settings for the web console UI")
 
 
 __all__ = ["AppConfig"]

--- a/papersys/config/web.py
+++ b/papersys/config/web.py
@@ -1,0 +1,57 @@
+"""Web console configuration models."""
+
+from __future__ import annotations
+
+from pydantic import Field, field_validator, model_validator
+
+from papersys.config.base import BaseConfig
+
+
+class WebAuthConfig(BaseConfig):
+    """Settings for protecting the web console and related APIs."""
+
+    enabled: bool = Field(
+        False, description="Whether header token authentication is enforced.",
+    )
+    header_name: str = Field(
+        "X-Console-Token",
+        description="Header to read the authentication token from.",
+        min_length=1,
+    )
+    token: str | None = Field(
+        default=None, description="Shared secret token required when enabled.",
+        min_length=1,
+    )
+
+    @field_validator("token")
+    @classmethod
+    def _strip_token(cls, token: str | None) -> str | None:
+        if token is None:
+            return None
+        stripped = token.strip()
+        return stripped if stripped else None
+
+    @model_validator(mode="after")
+    def _ensure_token_when_enabled(self) -> "WebAuthConfig":
+        if self.enabled and not self.token:
+            msg = "Authentication token must be provided when web auth is enabled."
+            raise ValueError(msg)
+        return self
+
+
+class WebUIConfig(BaseConfig):
+    """Top-level settings for the FastAPI web console."""
+
+    enabled: bool = Field(True, description="Whether to expose the HTML console UI.")
+    title: str = Field(
+        "PaperDigest Console",
+        description="Page title displayed on the console UI.",
+        min_length=1,
+    )
+    auth: WebAuthConfig | None = Field(
+        default=None,
+        description="Authentication settings for the console and its APIs.",
+    )
+
+
+__all__ = ["WebAuthConfig", "WebUIConfig"]

--- a/papersys/web/app.py
+++ b/papersys/web/app.py
@@ -1,31 +1,55 @@
-from typing import Any
+"""FastAPI application factory and routing definitions."""
 
-from fastapi import FastAPI, HTTPException
+from __future__ import annotations
+
+import secrets
+from pathlib import Path
+from typing import Any, Callable
+
+from fastapi import Depends, FastAPI, Header, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
 from loguru import logger
 
+from papersys.config.app import AppConfig
+from papersys.config.web import WebAuthConfig
 from papersys.scheduler.service import SchedulerService
 
 
-def create_app(scheduler_service: SchedulerService) -> FastAPI:
-    """Creates and configures a FastAPI application."""
+def create_app(scheduler_service: SchedulerService, config: AppConfig | None = None) -> FastAPI:
+    """Creates and configures a FastAPI application with optional UI and auth."""
+    web_config = config.web if config and config.web else None
+    auth_config = web_config.auth if web_config and web_config.auth else None
+    auth_dependency = _build_auth_dependency(auth_config)
+
     app = FastAPI(
         title="PaperDigestMono API",
         description="API for managing and monitoring the paper processing pipeline.",
         version="0.1.0",
     )
 
+    templates = Jinja2Templates(directory=str(_templates_dir()))
+
     @app.get("/health", summary="Health Check", tags=["Monitoring"])
     async def health_check() -> dict[str, str]:
         """Check if the API is running."""
         return {"status": "ok"}
 
-    @app.get("/jobs", summary="List All Scheduled Jobs", tags=["Scheduler"])
-    async def list_jobs() -> list[dict[str, Any]]:
+    @app.get(
+        "/jobs",
+        summary="List All Scheduled Jobs",
+        tags=["Scheduler"],
+    )
+    async def list_jobs(_: None = Depends(auth_dependency)) -> list[dict[str, Any]]:
         """Returns a list of all configured jobs in the scheduler."""
         return scheduler_service.list_jobs()
 
-    @app.post("/scheduler/run/{job_id}", summary="Manually Run a Job", tags=["Scheduler"])
-    async def run_job(job_id: str) -> dict[str, str]:
+    @app.post(
+        "/scheduler/run/{job_id}",
+        summary="Manually Run a Job",
+        tags=["Scheduler"],
+    )
+    async def run_job(job_id: str, _: None = Depends(auth_dependency)) -> dict[str, str]:
         """
         Triggers a specific scheduled job to run immediately.
         """
@@ -35,4 +59,60 @@ def create_app(scheduler_service: SchedulerService) -> FastAPI:
 
         return {"status": "success", "message": f"Job '{job_id}' has been scheduled to run."}
 
+    @app.get("/console", response_class=HTMLResponse, include_in_schema=False)
+    async def console(request: Request) -> HTMLResponse:
+        """Render the lightweight scheduler console UI."""
+        if web_config is None or not web_config.enabled:
+            raise HTTPException(status_code=404, detail="Web console is disabled.")
+
+        template_context = {
+            "request": request,
+            "title": web_config.title,
+            "auth_enabled": bool(auth_config and auth_config.enabled),
+            "header_name": auth_config.header_name if auth_config else "X-Console-Token",
+        }
+        return templates.TemplateResponse(request, "console.html", template_context)
+
+    @app.get("/", include_in_schema=False)
+    async def root() -> RedirectResponse:
+        """Redirect to the console when available."""
+        if web_config and web_config.enabled:
+            return RedirectResponse(url="/console")
+        raise HTTPException(status_code=404, detail="Web console is disabled.")
+
     return app
+
+
+def _templates_dir() -> Path:
+    """Return the directory containing HTML templates."""
+    return Path(__file__).resolve().parent / "templates"
+
+
+def _build_auth_dependency(auth_config: WebAuthConfig | None) -> Callable[..., Any]:
+    """Return a dependency that validates the configured auth token."""
+
+    if not auth_config or not auth_config.enabled:
+        async def _no_auth() -> None:  # pragma: no cover - trivial branch
+            return None
+
+        return _no_auth
+
+    expected_token = auth_config.token or ""
+    header_alias = auth_config.header_name
+
+    async def _verify_token(
+        provided_token: str | None = Header(default=None, alias=header_alias),
+    ) -> None:
+        if provided_token is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Missing authentication token.",
+            )
+
+        if not secrets.compare_digest(provided_token, expected_token):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid authentication token.",
+            )
+
+    return _verify_token

--- a/papersys/web/templates/console.html
+++ b/papersys/web/templates/console.html
@@ -1,0 +1,348 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{ title }}</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      }
+      body {
+        margin: 0;
+        padding: 0;
+        background: var(--surface, #f5f5f5);
+        color: inherit;
+      }
+      header {
+        background: linear-gradient(135deg, #3f51b5, #2196f3);
+        color: #fff;
+        padding: 1.5rem 1rem;
+        text-align: center;
+      }
+      main {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+      }
+      h1 {
+        margin: 0 0 0.5rem 0;
+        font-size: clamp(1.8rem, 3vw, 2.5rem);
+      }
+      p.lead {
+        margin: 0;
+        font-size: 1rem;
+        opacity: 0.85;
+      }
+      section {
+        background: #ffffff;
+        border-radius: 12px;
+        padding: 1.5rem;
+        margin-top: 1.5rem;
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      th,
+      td {
+        padding: 0.75rem 0.5rem;
+        text-align: left;
+      }
+      th {
+        font-size: 0.85rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        opacity: 0.7;
+      }
+      tbody tr:nth-child(even) {
+        background: rgba(33, 150, 243, 0.05);
+      }
+      button.trigger {
+        padding: 0.5rem 0.75rem;
+        border: none;
+        border-radius: 999px;
+        background: #2196f3;
+        color: #fff;
+        cursor: pointer;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+      button.trigger:focus {
+        outline: 2px solid rgba(63, 81, 181, 0.5);
+        outline-offset: 2px;
+      }
+      button.trigger:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 8px 18px rgba(33, 150, 243, 0.35);
+      }
+      .status-banner {
+        margin-top: 1rem;
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        display: none;
+      }
+      .status-banner[data-state="success"] {
+        display: block;
+        background: rgba(76, 175, 80, 0.2);
+        color: #1b5e20;
+      }
+      .status-banner[data-state="error"] {
+        display: block;
+        background: rgba(244, 67, 54, 0.2);
+        color: #b71c1c;
+      }
+      .toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        align-items: center;
+        margin-top: 1.5rem;
+      }
+      .toolbar label {
+        font-weight: 600;
+      }
+      .toolbar input[type="password"],
+      .toolbar input[type="text"] {
+        border-radius: 6px;
+        border: 1px solid rgba(0, 0, 0, 0.2);
+        padding: 0.5rem 0.75rem;
+        min-width: 220px;
+      }
+      .toolbar button.save-token {
+        background: transparent;
+        color: #fff;
+        border: 1px solid rgba(255, 255, 255, 0.7);
+      }
+      .toolbar button.save-token:hover {
+        background: rgba(255, 255, 255, 0.15);
+        color: #fff;
+      }
+      @media (max-width: 600px) {
+        section {
+          padding: 1rem;
+        }
+        th,
+        td {
+          font-size: 0.9rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>{{ title }}</h1>
+      <p class="lead">Monitor scheduled jobs and trigger them on demand.</p>
+      {% if auth_enabled %}
+      <div class="toolbar" role="region" aria-live="polite">
+        <label for="token-input">Access token</label>
+        <input
+          id="token-input"
+          type="password"
+          autocomplete="off"
+          aria-describedby="token-hint"
+        />
+        <button type="button" class="trigger save-token" id="store-token">
+          Save token
+        </button>
+        <span id="token-hint">Stored locally in this browser only.</span>
+      </div>
+      {% endif %}
+    </header>
+    <main>
+      <section aria-labelledby="jobs-heading">
+        <h2 id="jobs-heading">Scheduled jobs</h2>
+        <div id="jobs-container" role="region" aria-live="polite">
+          <p>Loading jobs…</p>
+        </div>
+        <div class="status-banner" id="status-banner"></div>
+      </section>
+    </main>
+    <script>
+      (function () {
+        const authEnabled = {{ auth_enabled | tojson }};
+        const headerName = {{ header_name | tojson }};
+        const jobsContainer = document.getElementById('jobs-container');
+        const statusBanner = document.getElementById('status-banner');
+        const tokenInput = document.getElementById('token-input');
+        const storeBtn = document.getElementById('store-token');
+        const STORAGE_KEY = 'paperdigest-console-token';
+
+        function setStatus(message, state) {
+          if (!statusBanner) return;
+          statusBanner.textContent = message;
+          if (state) {
+            statusBanner.setAttribute('data-state', state);
+          } else {
+            statusBanner.removeAttribute('data-state');
+          }
+        }
+
+        function getToken() {
+          if (!authEnabled) {
+            return null;
+          }
+          const current = tokenInput ? tokenInput.value.trim() : '';
+          if (current) {
+            return current;
+          }
+          try {
+            return localStorage.getItem(STORAGE_KEY);
+          } catch (err) {
+            console.warn('Unable to access localStorage', err);
+          }
+          return null;
+        }
+
+        function persistToken() {
+          if (!authEnabled || !tokenInput) {
+            return;
+          }
+          const value = tokenInput.value.trim();
+          try {
+            if (value) {
+              localStorage.setItem(STORAGE_KEY, value);
+            } else {
+              localStorage.removeItem(STORAGE_KEY);
+            }
+            setStatus('Token preference saved locally.', 'success');
+            fetchJobs();
+          } catch (err) {
+            setStatus('Unable to persist token: ' + err, 'error');
+          }
+        }
+
+        function loadInitialToken() {
+          if (!authEnabled || !tokenInput) {
+            return;
+          }
+          try {
+            const stored = localStorage.getItem(STORAGE_KEY);
+            if (stored) {
+              tokenInput.value = stored;
+            }
+          } catch (err) {
+            console.warn('Unable to read stored token', err);
+          }
+        }
+
+        async function fetchJobs() {
+          setStatus('', null);
+          const headers = new Headers();
+          if (authEnabled) {
+            const token = getToken();
+            if (!token) {
+              setStatus('Enter your access token to load jobs.', 'error');
+              jobsContainer.innerHTML = '<p>Token required to display jobs.</p>';
+              return;
+            }
+            headers.set(headerName, token);
+          }
+          try {
+            const response = await fetch('/jobs', { headers });
+            if (!response.ok) {
+              const detail = await response.json().catch(() => ({}));
+              throw new Error(detail.detail || 'Failed to load jobs.');
+            }
+            const jobs = await response.json();
+            renderJobs(jobs);
+          } catch (error) {
+            jobsContainer.innerHTML = '<p role="alert">' +
+              (error instanceof Error ? error.message : 'Unable to load jobs.') +
+              '</p>';
+            setStatus('Failed to load jobs.', 'error');
+          }
+        }
+
+        function renderJobs(jobs) {
+          if (!Array.isArray(jobs) || jobs.length === 0) {
+            jobsContainer.innerHTML = '<p>No jobs registered.</p>';
+            return;
+          }
+          const rows = jobs
+            .map(
+              (job) => `
+                <tr>
+                  <td>${job.id}</td>
+                  <td>${job.name ?? ''}</td>
+                  <td><code>${job.trigger ?? ''}</code></td>
+                  <td>
+                    <button class="trigger" data-job="${job.id}" aria-label="Run ${job.id} now">
+                      ▶ Run
+                    </button>
+                  </td>
+                </tr>
+              `,
+            )
+            .join('');
+          jobsContainer.innerHTML = `
+            <table aria-describedby="jobs-heading">
+              <thead>
+                <tr>
+                  <th scope="col">ID</th>
+                  <th scope="col">Name</th>
+                  <th scope="col">Schedule</th>
+                  <th scope="col">Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${rows}
+              </tbody>
+            </table>
+          `;
+        }
+
+        async function triggerJob(jobId) {
+          setStatus('Triggering job ' + jobId + '…', null);
+          const headers = new Headers({ 'Content-Type': 'application/json' });
+          if (authEnabled) {
+            const token = getToken();
+            if (!token) {
+              setStatus('Token required to trigger jobs.', 'error');
+              return;
+            }
+            headers.set(headerName, token);
+          }
+          try {
+            const response = await fetch('/scheduler/run/' + encodeURIComponent(jobId), {
+              method: 'POST',
+              headers,
+            });
+            if (!response.ok) {
+              const detail = await response.json().catch(() => ({}));
+              throw new Error(detail.detail || 'Trigger failed.');
+            }
+            setStatus('Job ' + jobId + ' triggered successfully.', 'success');
+          } catch (error) {
+            setStatus(
+              error instanceof Error ? error.message : 'Unable to trigger job.',
+              'error',
+            );
+          }
+        }
+
+        jobsContainer.addEventListener('click', (event) => {
+          const target = event.target;
+          if (target instanceof HTMLElement && target.matches('button.trigger')) {
+            const jobId = target.getAttribute('data-job');
+            if (jobId) {
+              triggerJob(jobId);
+            }
+          }
+        });
+
+        if (storeBtn) {
+          storeBtn.addEventListener('click', persistToken);
+        }
+
+        loadInitialToken();
+        fetchJobs();
+      })();
+    </script>
+  </body>
+</html>

--- a/tests/web/test_app.py
+++ b/tests/web/test_app.py
@@ -1,15 +1,18 @@
+"""HTTP-level tests for the FastAPI web console and APIs."""
+
+from __future__ import annotations
+
 import pytest
 from fastapi.testclient import TestClient
 
 from papersys.config import AppConfig, SchedulerConfig, SchedulerJobConfig
+from papersys.config.web import WebAuthConfig, WebUIConfig
 from papersys.scheduler import SchedulerService
 from papersys.web import create_app
 
 
-@pytest.fixture
-def mock_scheduler_service() -> SchedulerService:
-    """Provides a SchedulerService with a mock config."""
-    config = AppConfig(
+def _build_app_config(web: WebUIConfig | None) -> AppConfig:
+    return AppConfig(
         data_root=None,
         scheduler_enabled=True,
         logging_level="INFO",
@@ -22,49 +25,118 @@ def mock_scheduler_service() -> SchedulerService:
             summary_job=SchedulerJobConfig(
                 enabled=True, name="test-summary", cron="* * * * *"
             ),
-        )
+        ),
+        web=web,
     )
-    service = SchedulerService(config)
-    service.setup_jobs()
-    return service
 
 
 @pytest.fixture
-def client(mock_scheduler_service: SchedulerService) -> TestClient:
-    """Provides a TestClient for the FastAPI app."""
-    app = create_app(mock_scheduler_service)
+def config_without_auth() -> AppConfig:
+    """Configuration with the console enabled but auth disabled."""
+    web = WebUIConfig(enabled=True, title="Test Console", auth=None)
+    return _build_app_config(web)
+
+
+@pytest.fixture
+def config_with_auth() -> AppConfig:
+    """Configuration with header token authentication enabled."""
+    web = WebUIConfig(
+        enabled=True,
+        title="Secured Console",
+        auth=WebAuthConfig(enabled=True, header_name="X-Test-Token", token="secret-token"),
+    )
+    return _build_app_config(web)
+
+
+def _build_client(config: AppConfig) -> TestClient:
+    service = SchedulerService(config)
+    service.setup_jobs()
+    app = create_app(service, config)
     return TestClient(app)
 
 
-def test_health_check(client: TestClient):
-    """Test the /health endpoint."""
+@pytest.fixture
+def client(config_without_auth: AppConfig) -> TestClient:
+    return _build_client(config_without_auth)
+
+
+@pytest.fixture
+def client_with_auth(config_with_auth: AppConfig) -> TestClient:
+    return _build_client(config_with_auth)
+
+
+def test_health_check(client: TestClient) -> None:
+    """The health endpoint should remain publicly accessible."""
     response = client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
 
 
-def test_list_jobs(client: TestClient):
-    """Test the /jobs endpoint."""
+def test_list_jobs_without_auth(client: TestClient) -> None:
+    """When auth is disabled the jobs endpoint responds without headers."""
     response = client.get("/jobs")
     assert response.status_code == 200
     jobs = response.json()
-    assert len(jobs) == 2
-    assert jobs[0]["id"] == "recommend"
-    assert jobs[1]["id"] == "summary"
+    assert [job["id"] for job in jobs] == ["recommend", "summary"]
 
 
-def test_run_job_successfully(client: TestClient):
-    """Test the /scheduler/run/{job_id} endpoint for a valid job."""
-    response = client.post("/scheduler/run/recommend")
+def test_console_page_renders_html(client: TestClient) -> None:
+    """The HTML console should render when enabled."""
+    response = client.get("/console")
     assert response.status_code == 200
-    assert response.json() == {
-        "status": "success",
-        "message": "Job 'recommend' has been scheduled to run.",
-    }
+    assert "text/html" in response.headers["content-type"]
+    body = response.text
+    assert "Scheduled jobs" in body
+    assert "Save token" not in body  # Token UI hidden when auth disabled
 
 
-def test_run_nonexistent_job(client: TestClient):
-    """Test running a job that does not exist."""
-    response = client.post("/scheduler/run/nonexistent")
+def test_jobs_endpoint_requires_token(client_with_auth: TestClient) -> None:
+    """Missing authentication headers should be rejected."""
+    response = client_with_auth.get("/jobs")
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Missing authentication token."
+
+
+def test_jobs_endpoint_accepts_token(client_with_auth: TestClient) -> None:
+    """Providing the correct token allows the request."""
+    response = client_with_auth.get("/jobs", headers={"X-Test-Token": "secret-token"})
+    assert response.status_code == 200
+    jobs = response.json()
+    assert len(jobs) == 2
+
+
+def test_run_job_requires_valid_token(client_with_auth: TestClient) -> None:
+    """An incorrect token should not trigger jobs."""
+    response = client_with_auth.post(
+        "/scheduler/run/recommend",
+        headers={"X-Test-Token": "wrong"},
+    )
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid authentication token."
+
+
+def test_run_job_with_valid_token(client_with_auth: TestClient) -> None:
+    """The manual trigger works when a valid token is supplied."""
+    response = client_with_auth.post(
+        "/scheduler/run/recommend",
+        headers={"X-Test-Token": "secret-token"},
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "success"
+
+
+def test_run_unknown_job_returns_404(client_with_auth: TestClient) -> None:
+    """Unknown jobs should still report 404 after auth succeeds."""
+    response = client_with_auth.post(
+        "/scheduler/run/unknown",
+        headers={"X-Test-Token": "secret-token"},
+    )
     assert response.status_code == 404
-    assert response.json() == {"detail": "Job 'nonexistent' not found."}
+    assert response.json()["detail"] == "Job 'unknown' not found."
+
+
+def test_console_with_auth_shows_token_inputs(client_with_auth: TestClient) -> None:
+    """The UI should expose token controls when auth is enabled."""
+    response = client_with_auth.get("/console")
+    assert response.status_code == 200
+    assert "Access token" in response.text


### PR DESCRIPTION
## Summary
- add configurable web console authentication controls and expose a `/console` UI for job management
- surface configuration models and sample TOML settings for the new web console
- expand FastAPI tests to cover UI rendering and token-protected triggers, plus document usage in the README

## Testing
- uv run pytest


------
https://chatgpt.com/codex/tasks/task_e_68de0d50464c8333adc58712f76d6035