### PR TITLE
Add coverage for CLI command suite

### DIFF
--- a/devlog/2025-10-06-cli-standard-tests-plan.md
+++ b/devlog/2025-10-06-cli-standard-tests-plan.md
@@ -1,0 +1,34 @@
+# CLI 标准化测试与清洁化修正计划（2025-10-06）
+
+## 现状
+- Typer 重构后的 CLI 尚无针对顶层 callback 和 `status`、`summarize` 等通用命令的系统化测试覆盖，`tests/cli` 仅验证 `serve --dry-run` 与配置子命令。
+- `embed` 命令在 `if backlog:` 分支下直接堆叠了大段循环逻辑，违反既定 clean code 准则，降低可读性与可测试性。
+- 缺乏对默认入口（无子命令、`--dry-run` 兼容路径）的回归保障，容易在未来改动中引入行为回退。
+
+## 风险评估
+- 触发 CLI 命令时会加载完整配置并初始化多个服务，若测试用例构造的配置不当，可能意外访问网络/文件系统导致测试不稳定。
+- 抽取 backlog 处理函数时需保证所有日志与退出码语义保持不变，否则现有用户脚本可能受到影响。
+- 增补测试需与现有 logger 捕获逻辑兼容，避免造成 CI 噪音或 flaky 输出。
+
+## 实施方案
+1. 设计最小化的 TOML 配置片段，仅启用所需模块，确保 CLI 命令在测试中可重复执行且不触发外部依赖。
+2. 为 `status --dry-run` 与顶层 `--dry-run` 路径新增单元测试，覆盖日志输出与退出码；必要时抽取测试辅助函数，复用 log 捕获逻辑。
+3. 将 `embed` 命令 backlog 处理的长分支提炼为私有辅助函数，保持现有日志文本与统计逻辑，主流程仅负责调度。
+4. 运行并记录针对性与全量 pytest，确认新增测试通过且未破坏既有覆盖。
+
+## 回滚策略
+- 以单次 Git 提交为回滚单元；如测试新增导致失败，可首先回退测试文件，确认 CLI 行为保持稳定后再排查。
+- 若 backlog 抽取后的逻辑出现回归，可将新辅助函数恢复为内联实现，同时保留新增测试帮助复现问题。
+
+## 测试计划
+- `uv run --no-progress pytest tests/cli/test_cli_status.py`
+- `uv run --no-progress pytest tests/cli`
+- `uv run --no-progress pytest`
+
+## 后续跟踪
+- 根据测试效果评估是否需要为其它 Typer 子命令（如 `ingest`、`embed` 标准路径）补充集成测试，纳入 TODO 列表。
+
+## 执行记录（2025-10-06）
+- 复用最小化配置生成器新增 `tests/cli/test_cli_status.py`，覆盖 `status --dry-run` 与顶层 `--dry-run` 两条关键路径。
+- 抽取 `_process_embedding_backlog` 辅助函数，简化 `embed` 命令中 backlog 分支的控制流，实现与原逻辑等价的日志与计数行为。
+- 使用 `uv run --no-progress pytest tests/cli/test_cli_status.py`、`uv run --no-progress pytest tests/cli` 与 `uv run --no-progress pytest` 验证所有测试全绿。

--- a/devlog/2025-10-07-cli-command-tests-plan.md
+++ b/devlog/2025-10-07-cli-command-tests-plan.md
@@ -1,0 +1,43 @@
+# CLI command test expansion plan (2025-10-07)
+
+## Context
+- Current Typer-based CLI has regression coverage limited to `status` dry-run flows.
+- Remaining commands (`summarize`, `serve`, `ingest`, `embed`, `config check`, `config explain`) rely on external services and were untested.
+- User feedback highlighted the need to finish the CLI testing suite instead of deferring items to TODOs.
+
+## Goals
+- Provide automated tests that exercise every CLI command entry point without touching live services.
+- Validate critical behaviours: dry-run paths, argument plumbing, error handling, and output formatting.
+- Maintain clean code standards by isolating helper utilities for test scaffolding.
+
+## Approach
+1. Design reusable fixtures/helpers to synthesise an `AppConfig` object with minimal viable sub-configurations for each command.
+2. Use `monkeypatch` to stub service classes (`SummaryPipeline`, `SchedulerService`, `IngestionService`, `EmbeddingService`, `uvicorn.run`, config inspectors) to avoid I/O and observe interactions.
+3. Capture log output via Loguru to assert expected status messages while ensuring exit codes propagate correctly through `papersys.cli.main`.
+4. Extend existing CLI test suite with targeted cases per command, covering both default and flag-driven behaviours (e.g., backlog processing, JSON formatting).
+
+## Risks & Mitigations
+- **Risk:** Tight coupling to implementation details may cause brittle tests if CLI wiring changes.
+  - *Mitigation:* Focus assertions on observable behaviour (calls, exit codes, log statements) rather than internal attribute states.
+- **Risk:** Complex fixture setup could obscure intent.
+  - *Mitigation:* Keep helpers compact and document their purpose; prefer explicit per-test configuration when it improves clarity.
+
+## Test Plan
+- `uv run --no-progress pytest tests/cli/test_cli_status.py`
+- `uv run --no-progress pytest tests/cli/test_cli_commands.py`
+- `uv run --no-progress pytest`
+
+## Rollback Strategy
+- Revert the new tests and helper utilities if they introduce instability, retaining the documented plan for future iteration.
+
+## Follow-up Notes
+- Future work: integrate CLI command tests into CI smoke suite to prevent regressions.
+
+## Execution Log
+- Implemented shared CLI testing utilities for Loguru capture and in-memory AppConfig fabrication.
+- Added comprehensive command coverage in `tests/cli/test_cli_commands.py`, including summarize, serve, ingest, embed, and config subcommands.
+- Introduced `tests/cli/__init__.py` to enable package-relative imports and reused helpers in existing status tests.
+- Test runs:
+  - `uv run --no-progress pytest tests/cli/test_cli_commands.py`
+  - `uv run --no-progress pytest tests/cli/test_cli_status.py`
+  - `uv run --no-progress pytest`

--- a/papersys/cli.py
+++ b/papersys/cli.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-import argparse
 import json
-from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
+import typer
 import uvicorn
 from loguru import logger
 
@@ -18,168 +19,189 @@ from .scheduler import SchedulerService
 from .summary import SummaryPipeline
 from .web import create_app
 
+if TYPE_CHECKING:
+    from .embedding import EmbeddingService
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Papersys orchestration helpers")
-    parser.add_argument(
-        "--config",
-        type=Path,
-        default=_default_config_path(),
+
+@dataclass(slots=True)
+class CLIState:
+    """Holds shared state between Typer commands."""
+
+    config_path: Path
+    legacy_dry_run: bool = False
+    _config: AppConfig | None = None
+
+    def ensure_config(self) -> AppConfig:
+        if self._config is None:
+            logger.info("Loading configuration from {}", self.config_path)
+            self._config = load_config(AppConfig, self.config_path)
+        return self._config
+
+
+app = typer.Typer(help="Papersys orchestration helpers")
+config_app = typer.Typer(help="Validate and document configuration files")
+app.add_typer(config_app, name="config")
+
+
+def _default_config_path() -> Path:
+    repo_root = Path(__file__).resolve().parents[1]
+    return repo_root / "config" / "example.toml"
+
+
+def _normalize_format(value: str) -> str:
+    return value.lower()
+
+
+def _get_state(ctx: typer.Context) -> CLIState:
+    state = ctx.obj
+    if not isinstance(state, CLIState):  # pragma: no cover - defensive guard
+        raise RuntimeError("CLI context is not initialised")
+    return state
+
+
+def _exit(code: int) -> None:
+    raise typer.Exit(code)
+
+
+@app.callback(invoke_without_command=True)
+def main_callback(
+    ctx: typer.Context,
+    config: Path = typer.Option(
+        _default_config_path(),
         help="Path to the TOML configuration file",
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="(legacy) Equivalent to 'status --dry-run'",
-    )
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        help="(legacy) Equivalent to 'status --dry-run' when no command is provided",
+    ),
+) -> None:
+    """Initialise CLI state and handle legacy --dry-run usage."""
 
-    subparsers = parser.add_subparsers(dest="command")
+    state = CLIState(config_path=config.resolve(), legacy_dry_run=dry_run)
+    ctx.obj = state
 
-    status_parser = subparsers.add_parser("status", help="Show configuration and subsystem status")
-    status_parser.add_argument(
-        "--dry-run",
-        action="store_true",
+    if ctx.invoked_subcommand is None:
+        config_obj = state.ensure_config()
+        if dry_run:
+            _report_system_status(config_obj)
+            _exit(0)
+        logger.warning(
+            "No command provided. Try 'status --dry-run' or 'summarize --dry-run'."
+        )
+        _exit(0)
+
+
+@app.command(help="Show configuration and subsystem status")
+def status(
+    ctx: typer.Context,
+    dry_run: bool = typer.Option(
+        False,
         help="Load configuration and report subsystem availability",
-    )
+    ),
+) -> None:
+    state = _get_state(ctx)
+    config = state.ensure_config()
 
-    summarize_parser = subparsers.add_parser("summarize", help="Inspect or run the summary pipeline")
-    summarize_parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Validate the summary pipeline without executing external calls",
-    )
-
-    serve_parser = subparsers.add_parser("serve", help="Run the scheduler and API server")
-    serve_parser.add_argument(
-        "--host", type=str, default="127.0.0.1", help="Host to bind the API server to"
-    )
-    serve_parser.add_argument(
-        "--port", type=int, default=8000, help="Port to bind the API server to"
-    )
-    serve_parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Set up the scheduler and report status without running the server",
-    )
-
-    ingest_parser = subparsers.add_parser("ingest", help="Fetch arXiv metadata via OAI-PMH")
-    ingest_parser.add_argument(
-        "--from",
-        dest="from_date",
-        type=str,
-        help="Start date in YYYY-MM-DD format (defaults to config.ingestion.start_date)",
-    )
-    ingest_parser.add_argument(
-        "--to",
-        dest="until_date",
-        type=str,
-        help="End date in YYYY-MM-DD format (defaults to config.ingestion.end_date)",
-    )
-    ingest_parser.add_argument(
-        "--limit",
-        type=int,
-        help="Maximum number of records to fetch (for testing)",
-    )
-    ingest_parser.add_argument(
-        "--deduplicate",
-        action="store_true",
-        help="Deduplicate CSV files after ingestion",
-    )
-
-    embed_parser = subparsers.add_parser("embed", help="Generate embeddings for paper metadata")
-    embed_parser.add_argument(
-        "--model",
-        type=str,
-        help="Model alias to use (e.g., conan_v1, jasper_v1). If not specified, uses first enabled model",
-    )
-    embed_parser.add_argument(
-        "--limit",
-        type=int,
-        help="Maximum number of papers to process per CSV (for testing)",
-    )
-    embed_parser.add_argument(
-        "--backlog",
-        action="store_true",
-        help="Process backlog (CSV files without embeddings)",
-    )
-
-    config_parser = subparsers.add_parser("config", help="Validate and document configuration files")
-    config_subparsers = config_parser.add_subparsers(dest="config_command")
-    if hasattr(config_subparsers, "required"):
-        config_subparsers.required = True  # type: ignore[attr-defined]
-
-    check_parser = config_subparsers.add_parser("check", help="Validate the configuration file")
-    check_parser.add_argument(
-        "--format",
-        choices=("text", "json"),
-        default="text",
-        help="Output format for validation results",
-    )
-
-    explain_parser = config_subparsers.add_parser("explain", help="Describe available configuration fields")
-    explain_parser.add_argument(
-        "--format",
-        choices=("text", "json"),
-        default="text",
-        help="Output format for configuration schema",
-    )
-
-    return parser
-
-
-def main(argv: list[str] | None = None) -> int:
-    parser = build_parser()
-    args = parser.parse_args(argv)
-
-    config_path = args.config.resolve()
-    command = args.command
-
-    if command == "config":
-        return _handle_config_command(args, config_path)
-
-    logger.info("Loading configuration from {}", config_path)
-    config = load_config(AppConfig, config_path)
-
-    if command is None:
-        return _handle_no_command(args, config)
-
-    handler = _COMMAND_HANDLERS.get(command)
-    if handler is None:
-        logger.warning("Unknown command: {}", command)
-        return 1
-
-    return handler(args, config, config_path)
-
-
-def _handle_no_command(args: argparse.Namespace, config: AppConfig) -> int:
-    if args.dry_run:
+    if dry_run or state.legacy_dry_run:
         _report_system_status(config)
-        return 0
-    logger.warning("No command provided. Try 'status --dry-run' or 'summarize --dry-run'.")
-    return 0
-
-
-def _handle_status_command(args: argparse.Namespace, config: AppConfig, _: Path) -> int:
-    if getattr(args, "dry_run", False):
-        _report_system_status(config)
-        return 0
+        return
 
     logger.info("Status command currently supports --dry-run only; showing status.")
     _report_system_status(config)
-    return 0
 
 
-def _handle_ingest_command(args: argparse.Namespace, config: AppConfig, _: Path) -> int:
+@app.command(help="Inspect or run the summary pipeline")
+def summarize(
+    ctx: typer.Context,
+    dry_run: bool = typer.Option(
+        False,
+        help="Validate the summary pipeline without executing external calls",
+    ),
+) -> None:
+    state = _get_state(ctx)
+    config = state.ensure_config()
+    base_path = config.data_root or state.config_path.parent
+
+    try:
+        pipeline = SummaryPipeline(config, base_path=base_path)
+    except ValueError as exc:
+        logger.error("Cannot initialise summary pipeline: {}", exc)
+        _exit(1)
+
+    if dry_run:
+        pipeline.run([], dry_run=True)
+        return
+
+    logger.warning(
+        "Summary execution requires input data which is not wired yet. Use --dry-run for checks."
+    )
+
+
+@app.command(help="Run the scheduler and API server")
+def serve(
+    ctx: typer.Context,
+    host: str = typer.Option("127.0.0.1", help="Host to bind the API server to"),
+    port: int = typer.Option(8000, help="Port to bind the API server to"),
+    dry_run: bool = typer.Option(
+        False,
+        help="Set up the scheduler and report status without running the server",
+    ),
+) -> None:
+    config = _get_state(ctx).ensure_config()
+
+    scheduler_service = SchedulerService(config, dry_run=dry_run)
+    scheduler_service.setup_jobs()
+
+    if dry_run:
+        logger.info("[Dry Run] Server will not be started.")
+        return
+
+    app_instance = create_app(scheduler_service)
+
+    @app_instance.on_event("startup")
+    async def startup_event() -> None:
+        logger.info("Application startup...")
+        scheduler_service.start()
+
+    @app_instance.on_event("shutdown")
+    async def shutdown_event() -> None:
+        logger.info("Application shutdown...")
+        scheduler_service.shutdown()
+
+    uvicorn.run(app_instance, host=host, port=port)
+
+
+@app.command(help="Fetch arXiv metadata via OAI-PMH")
+def ingest(
+    ctx: typer.Context,
+    from_date: str | None = typer.Option(
+        None,
+        "--from",
+        help="Start date in YYYY-MM-DD format (defaults to config.ingestion.start_date)",
+    ),
+    until_date: str | None = typer.Option(
+        None,
+        "--to",
+        help="End date in YYYY-MM-DD format (defaults to config.ingestion.end_date)",
+    ),
+    limit: int | None = typer.Option(
+        None,
+        help="Maximum number of records to fetch (for testing)",
+    ),
+    deduplicate: bool = typer.Option(
+        False,
+        help="Deduplicate CSV files after ingestion",
+    ),
+) -> None:
+    config = _get_state(ctx).ensure_config()
+
     if not config.ingestion or not config.ingestion.enabled:
         logger.error("Ingestion is not enabled in the configuration")
-        return 1
+        _exit(1)
 
     from papersys.ingestion import IngestionService
 
     service = IngestionService(config.ingestion)
-    from_date = getattr(args, "from_date", None)
-    until_date = getattr(args, "until_date", None)
-    limit = getattr(args, "limit", None)
 
     logger.info("Starting ingestion: from={}, to={}, limit={}", from_date, until_date, limit)
     fetched, saved = service.fetch_and_save(
@@ -189,57 +211,56 @@ def _handle_ingest_command(args: argparse.Namespace, config: AppConfig, _: Path)
     )
     logger.info("Ingestion complete: fetched={}, saved={}", fetched, saved)
 
-    if getattr(args, "deduplicate", False):
+    if deduplicate:
         logger.info("Deduplicating CSV files...")
         removed = service.deduplicate_csv_files()
         logger.info("Deduplicated {} records", removed)
 
-    return 0
 
+@app.command(help="Generate embeddings for paper metadata")
+def embed(
+    ctx: typer.Context,
+    model: str | None = typer.Option(
+        None,
+        help="Model alias to use (e.g., conan_v1, jasper_v1). If not specified, uses first enabled model",
+    ),
+    limit: int | None = typer.Option(
+        None,
+        help="Maximum number of papers to process per CSV (for testing)",
+    ),
+    backlog: bool = typer.Option(
+        False,
+        help="Process backlog (CSV files without embeddings)",
+    ),
+) -> None:
+    config = _get_state(ctx).ensure_config()
 
-def _handle_embed_command(args: argparse.Namespace, config: AppConfig, _: Path) -> int:
     if not config.embedding or not config.embedding.enabled:
         logger.error("Embedding is not enabled in the configuration")
-        return 1
+        _exit(1)
 
     from papersys.embedding import EmbeddingService
 
     service = EmbeddingService(config.embedding)
 
-    model_config = _select_embedding_model(config, getattr(args, "model", None))
+    model_config = _select_embedding_model(config, model)
     if model_config is None:
-        return 1
-
-    limit = getattr(args, "limit", None)
+        _exit(1)
 
     if not config.ingestion or not config.ingestion.output_dir:
         logger.error("Ingestion output_dir not configured; cannot locate metadata CSV files")
-        return 1
+        _exit(1)
 
     metadata_dir = Path(config.ingestion.output_dir)
 
-    if getattr(args, "backlog", False):
-        backlog = service.detect_backlog(metadata_dir, model_config.alias)
-        if not backlog:
-            logger.info("No backlog found for model {}", model_config.alias)
-            return 0
-
-        logger.info("Processing {} files in backlog", len(backlog))
-        total_count = 0
-        for csv_path in backlog:
-            count, _ = service.generate_embeddings_for_csv(
-                csv_path,
-                model_config,
-                limit=limit,
-            )
-            total_count += count
-        logger.info("Generated {} embeddings total", total_count)
-        return 0
+    if backlog:
+        _process_embedding_backlog(service, metadata_dir, model_config, limit)
+        return
 
     csv_files = list(metadata_dir.rglob("*.csv"))
     if not csv_files:
         logger.error("No CSV files found in {}", metadata_dir)
-        return 1
+        _exit(1)
 
     logger.info("Found {} CSV files", len(csv_files))
     total_count = 0
@@ -251,47 +272,79 @@ def _handle_embed_command(args: argparse.Namespace, config: AppConfig, _: Path) 
         )
         total_count += count
     logger.info("Generated {} embeddings total", total_count)
-    return 0
 
 
-def _handle_summarize_command(args: argparse.Namespace, config: AppConfig, config_path: Path) -> int:
-    base_path = config.data_root or config_path.parent
-    try:
-        pipeline = SummaryPipeline(config, base_path=base_path)
-    except ValueError as exc:
-        logger.error("Cannot initialise summary pipeline: {}", exc)
-        return 1
+@config_app.command(help="Validate the configuration file")
+def check(
+    ctx: typer.Context,
+    format: str = typer.Option(  # noqa: A002 - match CLI option name
+        "text",
+        "--format",
+        case_sensitive=False,
+        help="Output format for validation results",
+        callback=_normalize_format,
+    ),
+) -> None:
+    state = _get_state(ctx)
+    result, exit_code, _ = check_config(state.config_path)
 
-    if getattr(args, "dry_run", False):
-        pipeline.run([], dry_run=True)
-        return 0
+    if format == "json":
+        print(json.dumps(result, indent=2, ensure_ascii=False, default=str))
+        _exit(exit_code)
 
-    logger.warning("Summary execution requires input data which is not wired yet. Use --dry-run for checks.")
-    return 0
+    if result["status"] == "ok":
+        logger.info("Configuration OK: {}", result["config_path"])
+        for warning in result["warnings"]:
+            logger.warning(warning)
+    else:
+        error: dict[str, Any] = result["error"]
+        logger.error(
+            "Configuration error ({}) for {}: {}",
+            error["type"],
+            result["config_path"],
+            error["message"],
+        )
+        for detail in error.get("details", []):
+            location = detail["loc"] or "<root>"
+            logger.error("  - {}: {} ({})", location, detail["message"], detail["type"])
+
+    _exit(exit_code)
 
 
-def _handle_serve_command(args: argparse.Namespace, config: AppConfig, _: Path) -> int:
-    scheduler_service = SchedulerService(config, dry_run=args.dry_run)
-    scheduler_service.setup_jobs()
+@config_app.command(help="Describe available configuration fields")
+def explain(
+    format: str = typer.Option(  # noqa: A002 - match CLI option name
+        "text",
+        "--format",
+        case_sensitive=False,
+        help="Output format for configuration schema",
+        callback=_normalize_format,
+    ),
+) -> None:
+    fields = explain_config()
 
-    if args.dry_run:
-        logger.info("[Dry Run] Server will not be started.")
-        return 0
+    if format == "json":
+        print(json.dumps({"fields": fields}, indent=2, ensure_ascii=False, default=str))
+        return
 
-    app = create_app(scheduler_service)
-
-    @app.on_event("startup")
-    async def startup_event() -> None:
-        logger.info("Application startup...")
-        scheduler_service.start()
-
-    @app.on_event("shutdown")
-    async def shutdown_event() -> None:
-        logger.info("Application shutdown...")
-        scheduler_service.shutdown()
-
-    uvicorn.run(app, host=args.host, port=args.port)
-    return 0
+    logger.info("Configuration schema ({} fields):", len(fields))
+    for field in fields:
+        default_value = field["default"]
+        if isinstance(default_value, (dict, list)):
+            default_repr = json.dumps(default_value, ensure_ascii=False, default=str)
+        elif default_value is None:
+            default_repr = "None"
+        else:
+            default_repr = str(default_value)
+        description = field["description"] or "(no description)"
+        logger.info(
+            "  - {name}: type={type}, required={required}, default={default}, description={description}",
+            name=field["name"],
+            type=field["type"],
+            required="yes" if field["required"] else "no",
+            default=default_repr,
+            description=description,
+        )
 
 
 def _select_embedding_model(
@@ -316,73 +369,27 @@ def _select_embedding_model(
     return model_config
 
 
-COMMAND_HANDLER = Callable[[argparse.Namespace, AppConfig, Path], int]
+def _process_embedding_backlog(
+    service: "EmbeddingService",
+    metadata_dir: Path,
+    model_config: EmbeddingModelConfig,
+    limit: int | None,
+) -> None:
+    backlog_files = service.detect_backlog(metadata_dir, model_config.alias)
+    if not backlog_files:
+        logger.info("No backlog found for model {}", model_config.alias)
+        return
 
-
-_COMMAND_HANDLERS: dict[str, COMMAND_HANDLER] = {
-    "status": _handle_status_command,
-    "ingest": _handle_ingest_command,
-    "embed": _handle_embed_command,
-    "summarize": _handle_summarize_command,
-    "serve": _handle_serve_command,
-}
-
-
-def _handle_config_command(args: argparse.Namespace, config_path: Path) -> int:
-    config_command = getattr(args, "config_command", None)
-    output_format = getattr(args, "format", "text")
-
-    if config_command == "check":
-        result, exit_code, _ = check_config(config_path)
-        if output_format == "json":
-            print(json.dumps(result, indent=2, ensure_ascii=False, default=str))
-            return exit_code
-
-        if result["status"] == "ok":
-            logger.info("Configuration OK: {}", result["config_path"])
-            for warning in result["warnings"]:
-                logger.warning(warning)
-        else:
-            error = result["error"]
-            logger.error(
-                "Configuration error ({}) for {}: {}",
-                error["type"],
-                result["config_path"],
-                error["message"],
-            )
-            for detail in error.get("details", []):
-                location = detail["loc"] or "<root>"
-                logger.error("  - {}: {} ({})", location, detail["message"], detail["type"])
-        return exit_code
-
-    if config_command == "explain":
-        fields = explain_config()
-        if output_format == "json":
-            print(json.dumps({"fields": fields}, indent=2, ensure_ascii=False, default=str))
-            return 0
-
-        logger.info("Configuration schema ({} fields):", len(fields))
-        for field in fields:
-            default_value = field["default"]
-            if isinstance(default_value, (dict, list)):
-                default_repr = json.dumps(default_value, ensure_ascii=False, default=str)
-            elif default_value is None:
-                default_repr = "None"
-            else:
-                default_repr = str(default_value)
-            description = field["description"] or "(no description)"
-            logger.info(
-                "  - {name}: type={type}, required={required}, default={default}, description={description}",
-                name=field["name"],
-                type=field["type"],
-                required="yes" if field["required"] else "no",
-                default=default_repr,
-                description=description,
-            )
-        return 0
-
-    logger.warning("Unknown config subcommand: {}", config_command)
-    return 1
+    logger.info("Processing {} files in backlog", len(backlog_files))
+    total_count = 0
+    for csv_path in backlog_files:
+        count, _ = service.generate_embeddings_for_csv(
+            csv_path,
+            model_config,
+            limit=limit,
+        )
+        total_count += count
+    logger.info("Generated {} embeddings total", total_count)
 
 
 def _report_system_status(config: AppConfig) -> None:
@@ -465,10 +472,16 @@ def _report_system_status(config: AppConfig) -> None:
         logger.info("No LLMs configured")
 
 
-def _default_config_path() -> Path:
-    repo_root = Path(__file__).resolve().parents[1]
-    return repo_root / "config" / "example.toml"
+def main(argv: list[str] | None = None) -> int:
+    """Entry point compatible with setuptools console scripts."""
 
+    try:
+        result = app(args=argv, standalone_mode=False)
+    except typer.Exit as exc:  # pragma: no cover - Typer translates exit codes
+        return exc.exit_code
+    if isinstance(result, int):
+        return result
+    return 0
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "timeout-decorator>=0.5.0",
     "toml>=0.10.2",
     "torch>=2.8.0",
+    "typer>=0.19.2",
     "uvicorn>=0.37.0",
 ]
 

--- a/tests/cli/test_cli_commands.py
+++ b/tests/cli/test_cli_commands.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from papersys.cli import main
+
+from .utils import logger_to_stderr, make_app_config, patch_load_config
+
+
+@pytest.fixture()
+def config_path(tmp_path: Path) -> Path:
+    config_file = tmp_path / "config.toml"
+    config_file.write_text("placeholder = true")
+    return config_file
+
+
+def test_main_without_command_warns(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: Any,
+    config_path: Path,
+) -> None:
+    config = make_app_config(tmp_path)
+    patch_load_config(monkeypatch, config)
+
+    with logger_to_stderr():
+        exit_code = main(["--config", str(config_path)])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "No command provided" in captured.err
+
+
+def test_summarize_dry_run_executes_pipeline(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    config_path: Path,
+) -> None:
+    config = make_app_config(tmp_path)
+    patch_load_config(monkeypatch, config)
+
+    calls: dict[str, Any] = {}
+
+    class DummyPipeline:
+        def __init__(self, cfg: Any, base_path: Path | None = None) -> None:
+            calls["base_path"] = base_path
+
+        def run(self, sources: list[Any], dry_run: bool = False) -> list[Any]:
+            calls["run"] = dry_run
+            return []
+
+    monkeypatch.setattr("papersys.cli.SummaryPipeline", DummyPipeline)
+
+    exit_code = main(["--config", str(config_path), "summarize", "--dry-run"])
+
+    assert exit_code == 0
+    assert calls["base_path"] is not None
+    assert calls["run"] is True
+
+
+def test_summarize_without_dry_run_warns(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: Any,
+    config_path: Path,
+) -> None:
+    config = make_app_config(tmp_path)
+    patch_load_config(monkeypatch, config)
+
+    pipelines: list[Any] = []
+
+    class DummyPipeline:
+        def __init__(self, cfg: Any, base_path: Path | None = None) -> None:
+            self.run_called = False
+            pipelines.append(self)
+
+        def run(self, sources: list[Any], dry_run: bool = False) -> list[Any]:
+            self.run_called = True
+            return []
+
+    monkeypatch.setattr("papersys.cli.SummaryPipeline", DummyPipeline)
+
+    with logger_to_stderr():
+        exit_code = main(["--config", str(config_path), "summarize"])
+
+    assert exit_code == 0
+    assert pipelines
+    assert pipelines[0].run_called is False
+    captured = capsys.readouterr()
+    assert "Use --dry-run" in captured.err
+
+
+def test_serve_dry_run_sets_up_scheduler(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    config_path: Path,
+) -> None:
+    config = make_app_config(tmp_path)
+    patch_load_config(monkeypatch, config)
+
+    instances: list[Any] = []
+
+    class DummyScheduler:
+        def __init__(self, cfg: Any, dry_run: bool) -> None:
+            self.dry_run = dry_run
+            self.setup_called = False
+            self.start_called = False
+            instances.append(self)
+
+        def setup_jobs(self) -> None:
+            self.setup_called = True
+
+        def start(self) -> None:
+            self.start_called = True
+
+        def shutdown(self) -> None:
+            raise AssertionError("shutdown should not be called in dry-run")
+
+    monkeypatch.setattr("papersys.cli.SchedulerService", DummyScheduler)
+
+    def _unexpected_create_app(*_: Any) -> None:
+        raise AssertionError("create_app should not run in dry-run mode")
+
+    monkeypatch.setattr("papersys.cli.create_app", _unexpected_create_app)
+    monkeypatch.setattr("papersys.cli.uvicorn", object())
+
+    exit_code = main(["--config", str(config_path), "serve", "--dry-run"])
+
+    assert exit_code == 0
+    assert instances
+    scheduler = instances[0]
+    assert scheduler.dry_run is True
+    assert scheduler.setup_called is True
+    assert scheduler.start_called is False
+
+
+def test_serve_runs_uvicorn(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    config_path: Path,
+) -> None:
+    config = make_app_config(tmp_path)
+    patch_load_config(monkeypatch, config)
+
+    class DummyScheduler:
+        def __init__(self, cfg: Any, dry_run: bool) -> None:
+            self.dry_run = dry_run
+
+        def setup_jobs(self) -> None:
+            return None
+
+        def start(self) -> None:
+            return None
+
+        def shutdown(self) -> None:
+            return None
+
+    class DummyApp:
+        def on_event(self, _event: str):
+            def decorator(func: Any) -> Any:
+                return func
+
+            return decorator
+
+    run_args: dict[str, Any] = {}
+
+    monkeypatch.setattr("papersys.cli.SchedulerService", DummyScheduler)
+    monkeypatch.setattr("papersys.cli.create_app", lambda service: DummyApp())
+
+    class _UvicornModule:
+        @staticmethod
+        def run(*args: Any, **kwargs: Any) -> None:
+            run_args["args"] = args
+            run_args["kwargs"] = kwargs
+
+    monkeypatch.setattr("papersys.cli.uvicorn", _UvicornModule)
+
+    exit_code = main(["--config", str(config_path), "serve", "--host", "0.0.0.0", "--port", "9000"])
+
+    assert exit_code == 0
+    assert run_args["kwargs"]["host"] == "0.0.0.0"
+    assert run_args["kwargs"]["port"] == 9000
+
+
+def test_ingest_runs_service(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    config_path: Path,
+) -> None:
+    config = make_app_config(tmp_path)
+    patch_load_config(monkeypatch, config)
+
+    instances: list[Any] = []
+
+    class DummyIngestionService:
+        def __init__(self, cfg: Any) -> None:
+            self.cfg = cfg
+            self.fetch_args: dict[str, Any] | None = None
+            self.dedup_called = False
+            instances.append(self)
+
+        def fetch_and_save(self, **kwargs: Any) -> tuple[int, int]:
+            self.fetch_args = kwargs
+            return 5, 4
+
+        def deduplicate_csv_files(self) -> int:
+            self.dedup_called = True
+            return 2
+
+    monkeypatch.setattr("papersys.ingestion.IngestionService", DummyIngestionService)
+
+    exit_code = main(
+        [
+            "--config",
+            str(config_path),
+            "ingest",
+            "--from",
+            "2024-01-01",
+            "--to",
+            "2024-01-02",
+            "--limit",
+            "10",
+            "--deduplicate",
+        ]
+    )
+
+    assert exit_code == 0
+    assert instances
+    service = instances[0]
+    assert service.fetch_args == {
+        "from_date": "2024-01-01",
+        "until_date": "2024-01-02",
+        "limit": 10,
+    }
+    assert service.dedup_called is True
+
+
+def test_ingest_disabled_exits(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, config_path: Path, capsys: Any) -> None:
+    config = make_app_config(tmp_path, include_ingestion=False)
+    patch_load_config(monkeypatch, config)
+
+    with logger_to_stderr():
+        exit_code = main(["--config", str(config_path), "ingest"])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Ingestion is not enabled" in captured.err
+
+
+def test_embed_backlog_flow(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    config_path: Path,
+) -> None:
+    config = make_app_config(tmp_path)
+    patch_load_config(monkeypatch, config)
+
+    backlog_calls: dict[str, Any] = {}
+    instances: list[Any] = []
+
+    class DummyEmbeddingService:
+        def __init__(self, cfg: Any) -> None:
+            self.cfg = cfg
+            instances.append(self)
+
+        def detect_backlog(self, metadata_dir: Path, alias: str) -> list[Path]:
+            backlog_calls["metadata_dir"] = metadata_dir
+            backlog_calls["alias"] = alias
+            return [metadata_dir / "backlog.csv"]
+
+        def generate_embeddings_for_csv(
+            self,
+            csv_path: Path,
+            model_cfg: Any,
+            *,
+            limit: int | None = None,
+        ) -> tuple[int, Any]:
+            backlog_calls.setdefault("processed", []).append((csv_path, limit))
+            return 3, None
+
+    monkeypatch.setattr("papersys.embedding.EmbeddingService", DummyEmbeddingService)
+
+    exit_code = main(["--config", str(config_path), "embed", "--backlog", "--limit", "5"])
+
+    assert exit_code == 0
+    assert backlog_calls["alias"] == "test"
+    assert backlog_calls["processed"][0][1] == 5
+    assert instances
+
+
+def test_embed_full_generation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    config_path: Path,
+) -> None:
+    config = make_app_config(tmp_path)
+    patch_load_config(monkeypatch, config)
+
+    metadata_dir = Path(config.ingestion.output_dir)
+    sample_csv = metadata_dir / "sample.csv"
+    sample_csv.parent.mkdir(parents=True, exist_ok=True)
+    sample_csv.write_text("id,title\n1,Example\n")
+
+    instances: list[Any] = []
+
+    class DummyEmbeddingService:
+        def __init__(self, cfg: Any) -> None:
+            self.cfg = cfg
+            self.calls: list[Path] = []
+            instances.append(self)
+
+        def generate_embeddings_for_csv(
+            self,
+            csv_path: Path,
+            model_cfg: Any,
+            *,
+            limit: int | None = None,
+        ) -> tuple[int, Any]:
+            self.calls.append(csv_path)
+            return 1, None
+
+    monkeypatch.setattr("papersys.embedding.EmbeddingService", DummyEmbeddingService)
+
+    exit_code = main(["--config", str(config_path), "embed", "--limit", "2"])
+
+    assert exit_code == 0
+    assert instances
+    assert instances[0].calls == [sample_csv]
+
+
+def test_config_check_json_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    config_path: Path,
+    capsys: Any,
+) -> None:
+    config = make_app_config(tmp_path)
+    patch_load_config(monkeypatch, config)
+
+    result_payload = {
+        "status": "ok",
+        "config_path": str(config_path),
+        "warnings": [],
+    }
+
+    monkeypatch.setattr(
+        "papersys.cli.check_config",
+        lambda path: (result_payload, 0, {}),
+    )
+
+    with logger_to_stderr():
+        exit_code = main(["--config", str(config_path), "config", "check", "--format", "json"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert result_payload["config_path"] in captured.out
+
+
+def test_config_check_text_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    config_path: Path,
+    capsys: Any,
+) -> None:
+    config = make_app_config(tmp_path)
+    patch_load_config(monkeypatch, config)
+
+    result_payload = {
+        "status": "error",
+        "config_path": str(config_path),
+        "warnings": [],
+        "error": {
+            "type": "validation",
+            "message": "boom",
+            "details": [{"loc": ["field"], "message": "missing", "type": "value_error"}],
+        },
+    }
+
+    monkeypatch.setattr(
+        "papersys.cli.check_config",
+        lambda path: (result_payload, 2, {}),
+    )
+
+    with logger_to_stderr():
+        exit_code = main(["--config", str(config_path), "config", "check"])
+
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "Configuration error" in captured.err
+    assert "field" in captured.err
+
+
+def test_config_explain_json_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    config_path: Path,
+    capsys: Any,
+) -> None:
+    config = make_app_config(tmp_path)
+    patch_load_config(monkeypatch, config)
+
+    monkeypatch.setattr(
+        "papersys.cli.explain_config",
+        lambda: [
+            {"name": "summary_pipeline.pdf.model", "type": "str", "required": True, "default": "llm"},
+        ],
+    )
+
+    exit_code = main(["--config", str(config_path), "config", "explain", "--format", "json"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "summary_pipeline.pdf.model" in captured.out
+
+
+def test_config_explain_text_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    config_path: Path,
+    capsys: Any,
+) -> None:
+    config = make_app_config(tmp_path)
+    patch_load_config(monkeypatch, config)
+
+    monkeypatch.setattr(
+        "papersys.cli.explain_config",
+        lambda: [
+            {
+                "name": "embedding.models",
+                "type": "list",
+                "required": False,
+                "default": [],
+                "description": "Configured embedding models",
+            }
+        ],
+    )
+
+    with logger_to_stderr():
+        exit_code = main(["--config", str(config_path), "config", "explain"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Configured embedding models" in captured.err

--- a/tests/cli/test_cli_status.py
+++ b/tests/cli/test_cli_status.py
@@ -1,0 +1,56 @@
+from papersys.cli import main
+
+from .utils import logger_to_stderr
+
+
+def _write_minimal_config(tmp_path):
+    config_text = """
+[scheduler]
+enabled = true
+timezone = "UTC"
+
+[ingestion]
+enabled = true
+output_dir = "metadata/raw"
+curated_dir = "metadata/curated"
+
+[embedding]
+enabled = true
+output_dir = "embeddings"
+
+[[embedding.models]]
+alias = "test"
+name = "sentence-transformer/test"
+dimension = 384
+"""
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(config_text)
+    return config_file
+
+
+def test_status_dry_run_reports_sections(capsys, tmp_path):
+    config_file = _write_minimal_config(tmp_path)
+
+    with logger_to_stderr():
+        exit_code = main(["--config", str(config_file), "status", "--dry-run"])
+
+    assert exit_code == 0
+
+    captured = capsys.readouterr()
+    assert "=== General Configuration ===" in captured.err
+    assert "=== Ingestion Configuration ===" in captured.err
+    assert "=== Embedding Configuration ===" in captured.err
+    assert "test: sentence-transformer/test (dim=384)" in captured.err
+
+
+def test_legacy_dry_run_invocation(capsys, tmp_path):
+    config_file = _write_minimal_config(tmp_path)
+
+    with logger_to_stderr():
+        exit_code = main(["--config", str(config_file), "--dry-run"])
+
+    assert exit_code == 0
+
+    captured = capsys.readouterr()
+    assert "=== General Configuration ===" in captured.err
+    assert "No command provided" not in captured.err

--- a/tests/cli/utils.py
+++ b/tests/cli/utils.py
@@ -1,0 +1,110 @@
+"""Shared helpers for CLI tests."""
+
+from __future__ import annotations
+
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+from loguru import logger
+from pytest import MonkeyPatch
+
+from papersys.config import (
+    AppConfig,
+    EmbeddingConfig,
+    EmbeddingModelConfig,
+    IngestionConfig,
+    LLMConfig,
+    PdfConfig,
+    SummaryPipelineConfig,
+)
+
+
+@contextmanager
+def logger_to_stderr(level: str = "INFO"):
+    """Temporarily route Loguru output to stderr for assertion."""
+
+    handler_id = logger.add(sys.stderr, level=level)
+    try:
+        yield
+    finally:
+        logger.remove(handler_id)
+
+
+def make_app_config(
+    base_dir: Path,
+    *,
+    include_ingestion: bool = True,
+    include_embedding: bool = True,
+    include_summary: bool = True,
+) -> AppConfig:
+    """Construct an in-memory AppConfig tailored for CLI tests."""
+
+    data_root = base_dir / "data"
+    data_root.mkdir(parents=True, exist_ok=True)
+
+    ingestion_cfg = None
+    if include_ingestion:
+        raw_dir = data_root / "metadata" / "raw"
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        curated_dir = data_root / "metadata" / "curated"
+        curated_dir.mkdir(parents=True, exist_ok=True)
+        ingestion_cfg = IngestionConfig(
+            enabled=True,
+            output_dir=str(raw_dir),
+            curated_dir=str(curated_dir),
+            categories=["cs.CL"],
+        )
+
+    embedding_cfg = None
+    embedding_models: list[EmbeddingModelConfig] = []
+    if include_embedding:
+        embed_dir = data_root / "embeddings"
+        embed_dir.mkdir(parents=True, exist_ok=True)
+        embedding_model = EmbeddingModelConfig(
+            alias="test",
+            name="sentence-transformer/test",
+            dimension=384,
+        )
+        embedding_models.append(embedding_model)
+        embedding_cfg = EmbeddingConfig(
+            enabled=True,
+            output_dir=str(embed_dir),
+            models=embedding_models,
+        )
+
+    summary_cfg = None
+    llms: list[LLMConfig] = []
+    if include_summary:
+        llm_config = LLMConfig(
+            alias="summary-llm",
+            name="mock-llm",
+            base_url="http://localhost",
+            api_key="dummy",
+        )
+        llms.append(llm_config)
+        summary_cfg = SummaryPipelineConfig(
+            pdf=PdfConfig(
+                output_dir="summaries/pdfs",
+                model=llm_config.alias,
+            )
+        )
+
+    return AppConfig(
+        data_root=data_root,
+        ingestion=ingestion_cfg,
+        embedding=embedding_cfg,
+        summary_pipeline=summary_cfg,
+        llms=llms,
+    )
+
+
+def patch_load_config(monkeypatch: MonkeyPatch, config: AppConfig) -> None:
+    """Force the CLI to return the provided config instead of reading from disk."""
+
+    def _fake_load_config(model: object, path: Path) -> AppConfig:
+        if model is not AppConfig:
+            raise AssertionError("Unexpected config model request")
+        return config
+
+    monkeypatch.setattr("papersys.cli.load_config", _fake_load_config)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 
 [[package]]
@@ -1559,6 +1559,7 @@ dependencies = [
     { name = "timeout-decorator" },
     { name = "toml" },
     { name = "torch" },
+    { name = "typer" },
     { name = "uvicorn" },
 ]
 
@@ -1586,6 +1587,7 @@ requires-dist = [
     { name = "timeout-decorator", specifier = ">=0.5.0" },
     { name = "toml", specifier = ">=0.10.2" },
     { name = "torch", specifier = ">=2.8.0" },
+    { name = "typer", specifier = ">=0.19.2" },
     { name = "uvicorn", specifier = ">=0.37.0" },
     { name = "vllm", marker = "extra == 'vllm'", specifier = ">=0.10.2", index = "https://wheels.vllm.ai/0.10.2/" },
 ]


### PR DESCRIPTION
## Summary
- document the CLI command test expansion plan and execution in devlog/2025-10-07-cli-command-tests-plan.md
- add shared CLI test utilities and package init to support reusable fixtures and logger capture
- add regression tests for summarize, serve, ingest, embed, and config subcommands to cover all CLI entry points

## Testing
- uv run --no-progress pytest tests/cli/test_cli_commands.py
- uv run --no-progress pytest tests/cli/test_cli_status.py
- uv run --no-progress pytest

------
https://chatgpt.com/codex/tasks/task_e_68de3f3db0808333ac376ad37619ca45