### PR TITLE
Remove redundant repository ids from recommendation config

### DIFF
--- a/config/example.toml
+++ b/config/example.toml
@@ -120,8 +120,6 @@ preference_dir = "./preferences"
 metadata_dir = "./metadata"
 metadata_pattern = "metadata-*.csv"
 embeddings_root = "./embeddings"
-embed_repo_id = "lyk/ArxivEmbedding"
-content_repo_id = "lyk/ArxivContent"
 background_start_year = 2024
 preference_start_year = 2023
 

--- a/devdoc/architecture.md
+++ b/devdoc/architecture.md
@@ -173,7 +173,7 @@ data/
 - **`recommend.py`**：
   - `LogisticRegressionConfig`：C、max_iter。
   - `TrainerConfig`：seed、bg_sample_rate、logistic_regression。
-  - `DataConfig`：categories、embedding_columns、preference_dir、metadata_dir、metadata_pattern、embeddings_root、background_start_year、preference_start_year、embed_repo_id、content_repo_id。
+  - `DataConfig`：categories、embedding_columns、preference_dir、metadata_dir、metadata_pattern、embeddings_root、background_start_year、preference_start_year。
   - `PredictConfig`：last_n_days、start_date、end_date、high_threshold、boundary_threshold、sample_rate、output_path。
   - `RecommendPipelineConfig`：聚合以上 data/trainer/predict 子节点。
 - **`summary.py`**：

--- a/papersys/config/recommend.py
+++ b/papersys/config/recommend.py
@@ -45,8 +45,6 @@ class DataConfig(BaseConfig):
     )
     background_start_year: int = Field(2024, ge=2000, description="Start year for background corpus")
     preference_start_year: int = Field(2023, ge=2000, description="Start year for preference data")
-    embed_repo_id: str = Field("lyk/ArxivEmbedding", description="HuggingFace repo for embeddings")
-    content_repo_id: str = Field("lyk/ArxivContent", description="HuggingFace repo for content data")
 
 
 class PredictConfig(BaseConfig):

--- a/tests/config/test_recommend_config.py
+++ b/tests/config/test_recommend_config.py
@@ -59,8 +59,6 @@ def test_recommend_pipeline_config_full(tmp_path: Path) -> None:
     embeddings_root = "./emb"
         background_start_year = 2023
         preference_start_year = 2022
-        embed_repo_id = "test/embed"
-        content_repo_id = "test/content"
 
         [trainer]
         seed = 99
@@ -93,8 +91,6 @@ def test_recommend_pipeline_config_full(tmp_path: Path) -> None:
     assert cfg.data.embeddings_root == "./emb"
     assert cfg.data.background_start_year == 2023
     assert cfg.data.preference_start_year == 2022
-    assert cfg.data.embed_repo_id == "test/embed"
-    assert cfg.data.content_repo_id == "test/content"
 
     # Trainer config
     assert cfg.trainer.seed == 99

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -33,8 +33,6 @@ def _build_app_config(base_dir: Path) -> AppConfig:
         categories=["cs.AI"],
         background_start_year=2024,
         preference_start_year=2024,
-        embed_repo_id="local/test-embeddings",
-        content_repo_id="local/test-content",
     )
     predict_cfg = PredictConfig(
         last_n_days=60,

--- a/tests/recommend/test_pipeline.py
+++ b/tests/recommend/test_pipeline.py
@@ -162,8 +162,6 @@ def recommendation_config(tmp_path: Path) -> AppConfig:
             embeddings_root=str(embeddings_root.relative_to(data_root)),
             background_start_year=2024,
             preference_start_year=2024,
-            embed_repo_id="local/embeddings",
-            content_repo_id="local/content",
         ),
         trainer=TrainerConfig(
             seed=123,
@@ -257,8 +255,6 @@ def test_loader_accepts_paper_id_preferences(tmp_path: Path) -> None:
             embeddings_root=str(embeddings_root.relative_to(data_root)),
             background_start_year=2024,
             preference_start_year=2024,
-            embed_repo_id="local/embeddings",
-            content_repo_id="local/content",
         ),
         trainer=TrainerConfig(
             seed=42,
@@ -345,8 +341,6 @@ def test_loader_filters_nan_embeddings(tmp_path: Path) -> None:
             embeddings_root=str(embeddings_root.relative_to(data_root)),
             background_start_year=2024,
             preference_start_year=2024,
-            embed_repo_id="local/embeddings",
-            content_repo_id="local/content",
         ),
         trainer=TrainerConfig(
             seed=42,


### PR DESCRIPTION
## Summary
- remove the unused embedding/content repository identifiers from the recommendation data configuration
- update the sample configuration, documentation, and tests to reflect the streamlined backup-driven workflow

## Testing
- uv run --no-progress pytest tests/config/test_recommend_config.py tests/recommend/test_pipeline.py tests/integration/test_full_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68df4f9bf1248333a89bd6adefc4e9fa